### PR TITLE
Add stable_deref_trait as an optional dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,3 +9,4 @@ readme = "README.md"
 license = "MIT/Apache-2.0"
 
 [dependencies]
+stable_deref_trait = { version = "1.2.0", optional = true }

--- a/src/owned.rs
+++ b/src/owned.rs
@@ -60,6 +60,9 @@ impl<T> DerefMut for Owned<T> {
     }
 }
 
+#[cfg(feature = "stable_deref_trait")]
+unsafe impl<T> stable_deref_trait::StableDeref for Owned<T> {}
+
 impl<T> Drop for Owned<T> {
     fn drop(&mut self) {
         unsafe {

--- a/src/shared.rs
+++ b/src/shared.rs
@@ -98,6 +98,9 @@ impl<T> Deref for Shared<T> {
     }
 }
 
+#[cfg(feature = "stable_deref_trait")]
+unsafe impl<T> stable_deref_trait::StableDeref for Shared<T> {}
+
 impl<T> Drop for Shared<T> {
     fn drop(&mut self) {
         unsafe {


### PR DESCRIPTION
This allows using Basedrop's `Owned` and `Shared` pointer types with self-referential struct libraries. :slightly_smiling_face: 

The dependency is optional and disabled by default.