### PR TITLE
remove useless PhantomData

### DIFF
--- a/src/owned.rs
+++ b/src/owned.rs
@@ -1,6 +1,5 @@
 use crate::{Handle, Node};
 
-use core::marker::PhantomData;
 use core::ops::{Deref, DerefMut};
 use core::ptr::NonNull;
 
@@ -15,7 +14,6 @@ use core::ptr::NonNull;
 /// [`Handle`]: crate::Handle
 pub struct Owned<T> {
     node: NonNull<Node<T>>,
-    phantom: PhantomData<T>,
 }
 
 unsafe impl<T: Send> Send for Owned<T> {}
@@ -34,7 +32,6 @@ impl<T: Send + 'static> Owned<T> {
     pub fn new(handle: &Handle, data: T) -> Owned<T> {
         Owned {
             node: unsafe { NonNull::new_unchecked(Node::alloc(handle, data)) },
-            phantom: PhantomData,
         }
     }
 }

--- a/src/shared.rs
+++ b/src/shared.rs
@@ -1,6 +1,5 @@
 use crate::{Handle, Node};
 
-use core::marker::PhantomData;
 use core::ops::Deref;
 use core::ptr::NonNull;
 use core::sync::atomic::{AtomicUsize, Ordering, fence};
@@ -17,7 +16,6 @@ use core::sync::atomic::{AtomicUsize, Ordering, fence};
 /// [`Handle`]: crate::Handle
 pub struct Shared<T> {
     pub(crate) node: NonNull<Node<SharedInner<T>>>,
-    pub(crate) phantom: PhantomData<SharedInner<T>>,
 }
 
 pub(crate) struct SharedInner<T> {
@@ -46,7 +44,6 @@ impl<T: Send + 'static> Shared<T> {
                     data,
                 }))
             },
-            phantom: PhantomData,
         }
     }
 }
@@ -86,7 +83,7 @@ impl<T> Clone for Shared<T> {
             self.node.as_ref().data.count.fetch_add(1, Ordering::Relaxed);
         }
 
-        Shared { node: self.node, phantom: PhantomData }
+        Shared { node: self.node }
     }
 }
 

--- a/src/shared_cell.rs
+++ b/src/shared_cell.rs
@@ -1,6 +1,5 @@
 use crate::{Node, Shared, SharedInner};
 
-use core::marker::PhantomData;
 use core::ptr::NonNull;
 use core::sync::atomic::{fence, AtomicPtr, AtomicUsize, Ordering};
 
@@ -13,7 +12,6 @@ use core::sync::atomic::{fence, AtomicPtr, AtomicUsize, Ordering};
 pub struct SharedCell<T> {
     readers: AtomicUsize,
     node: AtomicPtr<Node<SharedInner<T>>>,
-    phantom: PhantomData<Shared<T>>,
 }
 
 unsafe impl<T: Send + Sync> Send for SharedCell<T> {}
@@ -37,7 +35,6 @@ impl<T: Send + 'static> SharedCell<T> {
         SharedCell {
             readers: AtomicUsize::new(0),
             node: AtomicPtr::new(node),
-            phantom: PhantomData,
         }
     }
 }
@@ -63,7 +60,6 @@ impl<T> SharedCell<T> {
 
         let shared = Shared {
             node: unsafe { NonNull::new_unchecked(self.node.load(Ordering::SeqCst)) },
-            phantom: PhantomData,
         };
         let copy = shared.clone();
         core::mem::forget(shared);
@@ -119,7 +115,6 @@ impl<T> SharedCell<T> {
 
         Shared {
             node: unsafe { NonNull::new_unchecked(old) },
-            phantom: PhantomData,
         }
     }
 
@@ -144,7 +139,6 @@ impl<T> SharedCell<T> {
         core::mem::forget(self);
         Shared {
             node: unsafe { NonNull::new_unchecked(node.into_inner()) },
-            phantom: PhantomData,
         }
     }
 }
@@ -153,7 +147,6 @@ impl<T> Drop for SharedCell<T> {
     fn drop(&mut self) {
         let _ = Shared {
             node: unsafe { NonNull::new_unchecked(self.node.load(Ordering::Relaxed)) },
-            phantom: PhantomData,
         };
     }
 }


### PR DESCRIPTION
As far as i can see removing those PhantomData doesn't change anything about the Library and in my opinion makes the Data types clearer. I don't really know if it was needed on 2018 edition, but all the tests work (not miri but i work on fixing that).
If you want PhantomData as Documentation what each Type "is" i think it should be a comment as PhantomData "pollutes" the definition without any benefits.