### PR TITLE
Add T: ?Sized to every Smart Pointer in the Library

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "nightly"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "nightly"
+channel = "stable"

--- a/src/collector.rs
+++ b/src/collector.rs
@@ -34,13 +34,13 @@ pub struct Node<T: ?Sized> {
     /// Isn't `Node<T>` as that prohibits unsize coercion
     ///
     /// All fat pointers in Rust are the same size, so this works also for dyn
-    self_ptr: MaybeUninit<[u8; size_of::<&[()]>()]>,
+    self_ptr: MaybeUninit<*const [()]>,
     /// The data stored in this allocation.
     pub data: T,
 }
 
 unsafe fn drop_node<T: ?Sized>(node: *mut NodeHeader) {
-    /// This value is the same for every T
+    // This value is the same for every T
     let self_ptr_offset = const {
         offset_of!(Node<T>, self_ptr)
     };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,6 +17,7 @@
 
 #![no_std]
 #![feature(derive_smart_pointer)]
+#![feature(set_ptr_value)]
 
 mod collector;
 mod owned;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,7 +17,6 @@
 
 #![no_std]
 #![feature(derive_smart_pointer)]
-#![feature(set_ptr_value)]
 
 mod collector;
 mod owned;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,7 +16,6 @@
 //! [`SharedCell`]: crate::SharedCell
 
 #![no_std]
-#![feature(derive_smart_pointer)]
 
 mod collector;
 mod owned;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,6 +16,7 @@
 //! [`SharedCell`]: crate::SharedCell
 
 #![no_std]
+#![feature(derive_smart_pointer)]
 
 mod collector;
 mod owned;

--- a/src/owned.rs
+++ b/src/owned.rs
@@ -1,7 +1,6 @@
 use crate::{Handle, Node};
 
 use core::marker::PhantomData;
-use core::marker::SmartPointer;
 use core::ops::{Deref, DerefMut};
 use core::ptr::NonNull;
 
@@ -16,9 +15,8 @@ extern crate alloc;
 ///
 /// [`Collector`]: crate::Collector
 /// [`Handle`]: crate::Handle
-#[derive(SmartPointer)]
 #[repr(transparent)]
-pub struct Owned<#[pointee] T: ?Sized> {
+pub struct Owned<T: ?Sized> {
     node: NonNull<Node<T>>,
     phantom: PhantomData<T>,
 }
@@ -79,23 +77,5 @@ impl<T: ?Sized> Drop for Owned<T> {
         unsafe {
             Node::queue_drop(self.node.as_ptr());
         }
-    }
-}
-
-#[cfg(test)]
-mod test {
-    use core::any::Any;
-    use crate::{Collector, Owned};
-
-    #[test]
-    fn unsize_dyn() {
-        let mut collector = Collector::new();
-        let shared: Owned<[u8]> = Owned::new(&collector.handle(), [0, 1, 2, 3]);
-        let any: Owned<dyn Any> = Owned::new(&collector.handle(), 3u8);
-
-        drop(shared);
-        drop(any);
-        collector.collect();
-        assert!(collector.try_cleanup().is_ok());
     }
 }

--- a/src/owned.rs
+++ b/src/owned.rs
@@ -53,7 +53,7 @@ impl<T: Send + ?Sized + 'static> Owned<T> {
     }
 }
 
-impl<T: Clone + Send + ?Sized + 'static> Clone for Owned<T> {
+impl<T: Clone + Send + 'static> Clone for Owned<T> {
     fn clone(&self) -> Self {
         let handle = unsafe { Node::handle(self.node.as_ptr()) };
         Owned::new(&handle, self.deref().clone())

--- a/src/shared.rs
+++ b/src/shared.rs
@@ -1,6 +1,5 @@
 use crate::{Handle, Node};
 use core::alloc::Layout;
-use core::marker::SmartPointer;
 
 use core::marker::PhantomData;
 use core::ops::Deref;
@@ -21,9 +20,8 @@ use alloc::boxed::Box;
 ///
 /// [`Collector`]: crate::Collector
 /// [`Handle`]: crate::Handle
-#[derive(SmartPointer)]
 #[repr(transparent)]
-pub struct Shared<#[pointee] T: ?Sized> {
+pub struct Shared<T: ?Sized> {
     pub(crate) node: NonNull<Node<SharedInner<T>>>,
     pub(crate) phantom: PhantomData<SharedInner<T>>,
 }
@@ -161,24 +159,9 @@ mod tests {
 
     extern crate alloc;
 
-    use core::{
-        any::Any,
-        sync::atomic::{AtomicUsize, Ordering},
-    };
+    use core::sync::atomic::{AtomicUsize, Ordering};
 
     use alloc::boxed::Box;
-
-    #[test]
-    fn unsize_dyn() {
-        let mut collector = Collector::new();
-        let shared: Shared<[u8]> = Shared::new(&collector.handle(), [0, 1, 2, 3]);
-        let any: Shared<dyn Any> = Shared::new(&collector.handle(), 3u8);
-
-        drop(shared);
-        drop(any);
-        collector.collect();
-        assert!(collector.try_cleanup().is_ok());
-    }
 
     #[test]
     fn from_unsize_box() {


### PR DESCRIPTION
After almost giving up, i finally found a design that allows preserving the Metadata of fat pointers outside of the Atomic. Sadly the creation of the unsized type currently requires nightly ([derive_smart_pointer](https://github.com/rust-lang/rust/issues/123430)), so i don't assume this will get merged until that is stable.
(Maybe some APIs like copying the unsized data from a box into the Node would work on stable, but i didn't really test)
The nightly feature is also required by the Rust for Linux people, so maybe it will be stabilized soon.

would close #3 

### Design
I put a self-referential pointer inside of NodeHeader which stores the MetaData of the type. This also exists for Sized types, because otherwise the size of the type would need to change when doing the unsize coercion (not possible). This pointer is set when calling queue_drop, because it is only needed for dropping the node. before that i think (not sure) that the metadata could change (e.g. std::mem::swap) so i don't put it into there before.

This of course disallows moving the Node after calling queue_drop, but that is already not allowed as that would also dangle the ptr to the current node in the drop queue.

Then inside drop the constant offset (due to repr(C)) to the self_ptr is used to read it and cast it to the specific type. Then this ptr is used to drop the type.

The nightly feature [ptr_metadata](https://github.com/rust-lang/rust/issues/81513) would allow to only store the metadata and not a self ptr with it, but that wouldn't change much.

This doesn't add T: ?Sized for SharedCell because i honestly didn't spend enough time to understand the design of it, so i didn't find a place to put the metadata. Here the metadata also needs to exists before calling queue_drop, so it would need to be stored somewhere else than for the other pointer types.