### PR TITLE
Fix overly relaxed memory orderings in `Node::queue_drop` and `Collector::collect_one`

### DIFF
--- a/src/collector.rs
+++ b/src/collector.rs
@@ -98,7 +98,7 @@ impl<T> Node<T> {
         let collector = (*node).header.link.collector;
         (*node).header.link.next = ManuallyDrop::new(AtomicPtr::new(core::ptr::null_mut()));
         let tail = (*collector).tail.swap(node as *mut NodeHeader, Ordering::AcqRel);
-        (*tail).link.next.store(node as *mut NodeHeader, Ordering::Relaxed);
+        (*tail).link.next.store(node as *mut NodeHeader, Ordering::Release);
     }
 
     /// Gets a [`Handle`] to this `Node`'s associated [`Collector`].
@@ -277,7 +277,7 @@ impl Collector {
                 self.head = next;
                 if head == self.stub {
                     (*head).link.next.store(core::ptr::null_mut(), Ordering::Relaxed);
-                    let tail = (*self.inner).tail.swap(head, Ordering::Release);
+                    let tail = (*self.inner).tail.swap(head, Ordering::AcqRel);
                     (*tail).link.next.store(head, Ordering::Relaxed);
                 } else {
                     ((*head).drop)(head);


### PR DESCRIPTION
This commit fixes two issues. First, the final line of `Node::queue_drop` was using a relaxed memory ordering to store a pointer to the current node in the `next` field of the queue's existing tail node. This is insufficient for proper synchronization with the acquire load from the `next` field at the beginning of `Collector::collect_one`, and so it has been changed to a release store.

Second, the logic to re-queue the stub node in `Collector::collect_one` uses a release swap to write a pointer to the stub node to the `Collector`'s `tail` field, which means that load half of the swap was using a relaxed ordering. This is insufficient for proper synchronization with concurrent accesses to the `tail` field from `Node::queue_drop`, and so it has been changed to an acquire-release swap.

Fixes #7.